### PR TITLE
refactor: separate bundles for commonjs and esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,18 @@
   "name": "redstone-smartweave",
   "version": "0.3.10-alpha.1",
   "description": "An implementation of the SmartWeave SDK.",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/types/index.d.ts",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=12"
+  },
   "scripts": {
-    "build": "yarn run clean && tsc && 'tsc-alias'",
+    "build:cjs": "tsc -b tsconfig.json && tsc-alias -p tsconfig.json",
+    "build:esm": "tsc -b tsconfig.esm.json && tsc-alias -p tsconfig.esm.json",
+    "build:types": "tsc -b tsconfig.types.json && tsc-alias -p tsconfig.types.json",
+    "build": "yarn run clean && yarn build:cjs && yarn build:esm && yarn build:types",
     "format": "prettier --write 'src/**/*.ts'",
     "clean": "rimraf ./lib",
     "lint": "eslint . --ext .ts",

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -1,4 +1,4 @@
-import { EvalStateResult, EvaluationOptions, HandlerApi, InteractionResult, InteractionTx } from '@smartweave';
+import { EvalStateResult, EvaluationOptions, InteractionResult, InteractionTx } from '@smartweave';
 import { JWKInterface } from 'arweave/node/lib/wallet';
 
 /**

--- a/src/contract/HandlerBasedContract.ts
+++ b/src/contract/HandlerBasedContract.ts
@@ -1,10 +1,12 @@
 import {
   ArTransfer,
+  ArWallet,
   Benchmark,
   Contract,
   ContractInteraction,
   createTx,
   DefaultEvaluationOptions,
+  emptyTransfer,
   EvalStateResult,
   EvaluationOptions,
   ExecutionContext,
@@ -12,11 +14,9 @@ import {
   InteractionResult,
   InteractionTx,
   LoggerFactory,
+  sleep,
   SmartWeave,
-  Tags,
-  ArWallet,
-  emptyTransfer,
-  sleep
+  Tags
 } from '@smartweave';
 import { TransactionStatusResponse } from 'arweave/node/transactions';
 import { NetworkInfoInterface } from 'arweave/node/network';

--- a/src/core/modules/StateEvaluator.ts
+++ b/src/core/modules/StateEvaluator.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, GQLNodeInterface, HandlerApi } from '@smartweave';
+import { ExecutionContext, GQLNodeInterface } from '@smartweave';
 
 /**
  * Implementors of this class are responsible for evaluating contract's state

--- a/src/core/modules/impl/ContractDefinitionLoader.ts
+++ b/src/core/modules/impl/ContractDefinitionLoader.ts
@@ -1,12 +1,4 @@
-import {
-  Benchmark,
-  ContractDefinition,
-  DefinitionLoader,
-  getTag,
-  LoggerFactory,
-  SmartWeaveTags,
-  SwCache
-} from '@smartweave';
+import { ContractDefinition, DefinitionLoader, getTag, LoggerFactory, SmartWeaveTags, SwCache } from '@smartweave';
 import Arweave from 'arweave';
 import Transaction from 'arweave/web/lib/transaction';
 

--- a/src/logging/LoggerFactory.ts
+++ b/src/logging/LoggerFactory.ts
@@ -1,7 +1,6 @@
-import { RedStoneLogger, LogLevel } from '@smartweave';
-import { ConsoleLoggerFactory } from './web/ConsoleLoggerFactory';
-import { TsLogFactory } from './node/TsLogFactory';
+import { ConsoleLoggerFactory, LogLevel, RedStoneLogger } from '@smartweave';
 import { ISettingsParam } from 'tslog';
+import { TsLogFactory } from './node/TsLogFactory';
 
 export class LoggerFactory {
   static readonly INST: LoggerFactory = typeof window === 'undefined' ? new TsLogFactory() : new ConsoleLoggerFactory();

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,6 +1,5 @@
 export * from './web/ConsoleLogger';
 export * from './web/ConsoleLoggerFactory';
-export * from './node/TsLogFactory';
 export * from './RedStoneLogger';
 export * from './LoggerFactory';
 export * from './Benchmark';

--- a/src/logging/web/ConsoleLoggerFactory.ts
+++ b/src/logging/web/ConsoleLoggerFactory.ts
@@ -1,4 +1,4 @@
-import { RedStoneLogger, LogLevel } from '@smartweave';
+import { LogLevel, RedStoneLogger } from '@smartweave';
 import { ConsoleLogger } from './ConsoleLogger';
 import { ISettingsParam } from 'tslog';
 

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "lib/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,18 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compileOnSave": false,
   "compilerOptions": {
-    "sourceMap": true,
     "target": "es2019",
     "module": "commonjs",
-    "declaration": true,
-    "outDir": "./lib",
-    "esModuleInterop": true,
+    "types": ["jest", "node"],
+    "moduleResolution": "node",
+    "sourceMap": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true,
+    "outDir": "./lib/cjs",
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": "./src",
     "paths": {
       "@smartweave/cache": ["cache/index"],

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es2019",
+    "removeComments": false,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "./lib/types",
+    "outDir": "./lib/types",
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
Separate bundles for node and web env. - so that web bundlers (webpack, esbuild, rollup..) could effectively tree-shake code (ESM module format is required to do that)