### PR TITLE
fix: issue with contract 5pSyVjFI07z8mbLeQhYBMsQ4M_MPidXIGX6T77rnF2s …

### DIFF
--- a/src/__tests__/regression/test-cases.json
+++ b/src/__tests__/regression/test-cases.json
@@ -1,4 +1,5 @@
 [
+  "5pSyVjFI07z8mbLeQhYBMsQ4M_MPidXIGX6T77rnF2s",
   "-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ",
   "AVTqjPQGCCXim7Nl_gn3HMjE4k0Zi_eTFRJCNEVXZxw",
   "6eTVr8IKPNYbMHVcpHFXr-XNaL5hT6zRJXimcP-owmo",

--- a/src/cache/impl/BsonFileBlockHeightCache.ts
+++ b/src/cache/impl/BsonFileBlockHeightCache.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import BSON from 'bson';
 import { BlockHeightCacheResult, BlockHeightKey, BlockHeightSwCache } from '@smartweave/cache';
 import { Benchmark, LoggerFactory } from '@smartweave/logging';
+import { deepCopy } from '@smartweave/utils';
 
 /**
  * An implementation of {@link BlockHeightSwCache} that stores its data in BSON files.
@@ -130,7 +131,7 @@ export class BsonFileBlockHeightSwCache<V = any> implements BlockHeightSwCache<V
 
     return {
       cachedHeight: highestBlockHeight,
-      cachedValue: cached[highestBlockHeight + '']
+      cachedValue: deepCopy(cached[highestBlockHeight + ''])
     };
   }
 
@@ -157,7 +158,7 @@ export class BsonFileBlockHeightSwCache<V = any> implements BlockHeightSwCache<V
 
     return {
       cachedHeight: highestBlockHeight,
-      cachedValue: cached[highestBlockHeight + '']
+      cachedValue: deepCopy(cached[highestBlockHeight + ''])
     };
   }
 
@@ -170,8 +171,10 @@ export class BsonFileBlockHeightSwCache<V = any> implements BlockHeightSwCache<V
       this.updatedStorage[cacheKey] = {};
     }
 
-    this.storage[cacheKey][blockHeight + ''] = value;
-    this.updatedStorage[cacheKey][blockHeight + ''] = value;
+    const copiedValue = deepCopy(value);
+
+    this.storage[cacheKey][blockHeight + ''] = copiedValue;
+    this.updatedStorage[cacheKey][blockHeight + ''] = copiedValue;
     this.putCounter++;
     // update disk cache every 10 new entries
     if (this.putCounter === 10) {

--- a/src/cache/impl/MemBlockHeightCache.ts
+++ b/src/cache/impl/MemBlockHeightCache.ts
@@ -1,4 +1,5 @@
 import { BlockHeightCacheResult, BlockHeightKey, BlockHeightSwCache } from '@smartweave/cache';
+import { deepCopy } from '@smartweave/utils';
 
 /**
  * A simple, in-memory cache implementation of the BlockHeightSwCache
@@ -19,7 +20,7 @@ export class MemBlockHeightSwCache<V = any> implements BlockHeightSwCache<V> {
 
     return {
       cachedHeight: highestBlockHeight,
-      cachedValue: cached.get(highestBlockHeight)
+      cachedValue: deepCopy(cached.get(highestBlockHeight))
     };
   }
 
@@ -40,7 +41,7 @@ export class MemBlockHeightSwCache<V = any> implements BlockHeightSwCache<V> {
 
     return {
       cachedHeight: highestBlockHeight,
-      cachedValue: cached.get(highestBlockHeight)
+      cachedValue: deepCopy(cached.get(highestBlockHeight))
     };
   }
 
@@ -49,7 +50,7 @@ export class MemBlockHeightSwCache<V = any> implements BlockHeightSwCache<V> {
       this.storage[cacheKey] = new Map();
     }
 
-    this.storage[cacheKey].set(blockHeight, value);
+    this.storage[cacheKey].set(blockHeight, deepCopy(value));
   }
 
   async contains(key: string): Promise<boolean> {
@@ -67,7 +68,7 @@ export class MemBlockHeightSwCache<V = any> implements BlockHeightSwCache<V> {
 
     return {
       cachedHeight: blockHeight,
-      cachedValue: this.storage[key].get(blockHeight)
+      cachedValue: deepCopy(this.storage[key].get(blockHeight))
     };
   }
 }

--- a/src/core/modules/impl/HandlerExecutorFactory.ts
+++ b/src/core/modules/impl/HandlerExecutorFactory.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 import * as clarity from '@weavery/clarity';
 import {
   ContractDefinition,
+  deepCopy,
   ExecutionContext,
   ExecutorFactory,
   InteractionTx,
@@ -148,7 +149,7 @@ export class HandlerExecutorFactory implements ExecutorFactory<HandlerApi<unknow
       // but this (i.e. returning always stateWithValidity from here) would break backwards compatibility
       // in current contract's source code..:/
 
-      return returnValidity ? stateWithValidity : stateWithValidity.state;
+      return returnValidity ? deepCopy(stateWithValidity) : deepCopy(stateWithValidity.state);
     };
   }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,7 @@
 export const sleep = (ms: number) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
+
+export const deepCopy = (input: unknown) => {
+  return JSON.parse(JSON.stringify(input));
+};


### PR DESCRIPTION
…and memCached client #16

![image](https://user-images.githubusercontent.com/84311757/132865919-c8312e3e-4c8e-45cd-995a-af3248c63e2c.png)

The core issue here was that the contract was making some operations on state.balance value returned (in case of memCached client) from cache - but it was still the same reference, as the one being stored in cache - so any change made in contract was automatically reflected in an object stored in cache.